### PR TITLE
Add album and track handling to GMU

### DIFF
--- a/app/spotcamp/item_types.py
+++ b/app/spotcamp/item_types.py
@@ -1,0 +1,4 @@
+# Bancamp Item Types provided during search
+TRACK = 't'
+ALBUM = 'a'
+ARTISTS_AND_LABELS = 'b'

--- a/app/spotcamp/responses.py
+++ b/app/spotcamp/responses.py
@@ -25,6 +25,5 @@ class Response(Generic[T]):
     def failure(value: T = None):
         return Response(value=value, errors=None, status=Status.FAILURE)
 
-
     def is_failure(self) -> Boolean:
         return self.status == Status.FAILURE

--- a/app/spotcamp/spotcamp.py
+++ b/app/spotcamp/spotcamp.py
@@ -1,19 +1,66 @@
 from requests import Response
 import spotipy
-import os
 from urllib import parse
 from app.spotcamp.responses import Response
+import app.spotcamp.item_types as item_types
+import app.spotcamp.spotify_resource_types as spotify_resource_types
 
 
-def find_artists(spotify: spotipy.Spotify, query: str | None) -> Response:
+def find(spotify: spotipy.Spotify, query: str | None) -> Response:
     if not query:
         return Response.failure()
 
     result = parse.urlsplit(query)
-    (_, artist_id) = os.path.split(result.path)
+    (resource_type, resource_id) = [
+        s for s in result.path.split('/') if len(s) > 0]
+    bandcamp_query = _build_bandcamp_query(
+        item_name=_find_name(
+            spotify=spotify,
+            resource_id=resource_id,
+            resource_type=resource_type
+        )
+    )
+    item_type = _spotify_to_bandcamp_item_type(resource_type)
     try:
-        artist = spotify.artist(artist_id=artist_id)
-        search_url = f'https://bandcamp.com/search?item_type=b&q={artist["name"]}'
+        search_url = f'https://bandcamp.com/search?item_type={item_type}&q={bandcamp_query}'
         return Response.success(value=search_url)
     except:
         return Response.failure()
+
+
+def _build_bandcamp_query(item_name):
+    return parse.quote(item_name)
+
+
+def _find_name(spotify: spotipy.Spotify, resource_type: str, resource_id: str):
+    result = _find_resource(
+        spotify=spotify,
+        resource_type=resource_type,
+        resource_id=resource_id
+    )
+    if not result:
+        return None
+
+    return result['name']
+
+
+def _find_resource(spotify: spotipy.Spotify, resource_type: str, resource_id: str):
+    match resource_type:
+        case spotify_resource_types.ARTIST:
+            return spotify.artist(artist_id=resource_id)
+        case spotify_resource_types.TRACK:
+            return spotify.track(track_id=resource_id)
+        case spotify_resource_types.ALBUM:
+            return spotify.album(album_id=resource_id)
+
+    return None
+
+
+def _spotify_to_bandcamp_item_type(resource_type) -> str:
+    match resource_type:
+        case spotify_resource_types.ARTIST:
+            return item_types.ARTISTS_AND_LABELS
+        case spotify_resource_types.TRACK:
+            return item_types.TRACK
+        case spotify_resource_types.ALBUM:
+            return item_types.ALBUM

--- a/app/spotcamp/spotify_resource_types.py
+++ b/app/spotcamp/spotify_resource_types.py
@@ -1,0 +1,3 @@
+TRACK = 'track'
+ALBUM = 'album'
+ARTIST = 'artist'

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -17,7 +17,7 @@ def index():
 @app.route('/spotcamp')
 def get_spotcamp():
     query = request.args.get('q')
-    response = spotcamp.find_artists(spotify=spotify, query=query)
+    response = spotcamp.find(spotify=spotify, query=query)
 
     if response.is_failure():
         return redirect('/', code=302)

--- a/tests/test_spotcamp.py
+++ b/tests/test_spotcamp.py
@@ -1,3 +1,4 @@
+from urllib import parse
 from app.spotcamp import spotcamp
 from app.spotcamp.responses import Status
 
@@ -5,7 +6,7 @@ from app.spotcamp.responses import Status
 def test_find_artist_when_query_is_empty(mocker):
     spotify = mocker.Mock()
     query = ''
-    response = spotcamp.find_artists(query=query, spotify=spotify)
+    response = spotcamp.find(query=query, spotify=spotify)
     assert spotify.artist.call_count == 0
     assert response.is_failure()
 
@@ -15,8 +16,28 @@ def test_find_artist_when_query_url_is_present(mocker):
     artist_id = '6kBDZFXuLrZgHnvmPu9NsG'
     result_artist_name = 'Aphex Twin'
     query = f'https://open.spotify.com/artist/{artist_id}?si=HHxli1A0Qk2AFEp1OkVXgQ'
+    bandcamp_query = parse.quote(result_artist_name)
     spotify.artist.return_value = {'name': result_artist_name}
-    response = spotcamp.find_artists(query=query, spotify=spotify)
+
+    response = spotcamp.find(query=query, spotify=spotify)
+
     spotify.artist.assert_called_with(artist_id=artist_id)
     assert response.status == Status.SUCCESS
-    assert response.value == f'https://bandcamp.com/search?item_type=b&q={result_artist_name}'
+    assert response.value == f'https://bandcamp.com/search?item_type=b&q={bandcamp_query}'
+
+
+def test_find_song_with_artist(mocker):
+    spotify = mocker.Mock()
+    track_id = '1beOhReE4hMg0ti0181AcU'
+    result_track_name = 'All I See'
+    query = f'https://open.spotify.com/track/{track_id}?si=3f3e15dbecac473d'
+    bandcamp_query = parse.quote(result_track_name)
+    spotify.track.return_value = {
+        'name': result_track_name
+    }
+
+    response = spotcamp.find(query=query, spotify=spotify)
+
+    spotify.track.assert_called_with(track_id=track_id)
+    assert response.status == Status.SUCCESS
+    assert response.value == f'https://bandcamp.com/search?item_type=t&q={bandcamp_query}'


### PR DESCRIPTION
Adds parsing for the following resource types:

- Album URLs `https://open.spotify.com/album/6KjcqwPxz8Zuz9SypSzur2?si=uPgTrjXgQtKFSJd3-Dzkhg`
- Song URLs `https://open.spotify.com/track/2A4LY4QsEGRXxX6jhVcM3B?si=2355b512deee4043`